### PR TITLE
Fix onlineServices entries with empty URI dropped during vCard→JSContact conversion

### DIFF
--- a/src/jscontact/import/params.rs
+++ b/src/jscontact/import/params.rs
@@ -16,6 +16,12 @@ use crate::{
 use jmap_tools::{Key, Map, Value};
 
 impl ExtractedParams {
+    /// Returns true if this entry has online service parameters (SERVICE-TYPE or USERNAME)
+    /// that carry meaningful data even when the vCard entry value (URI) is empty.
+    pub(super) fn has_service_info(&self) -> bool {
+        self.service_type.is_some() || self.username.is_some()
+    }
+
     pub(super) fn prop_id(&mut self) -> Option<String> {
         self.prop_id.take()
     }

--- a/src/jscontact/import/props.rs
+++ b/src/jscontact/import/props.rs
@@ -248,6 +248,50 @@ where
             }
 
             self.track_prop(&entry.entry, top_property_name, alt_id, prop_id);
+        } else {
+            // Handle entries with no value but meaningful parameters.
+            // SOCIALPROFILE/IMPP entries may have SERVICE-TYPE and USERNAME as
+            // parameters with an empty URI value. The uri field is optional in
+            // JSContact OnlineService (RFC 9553 Section 2.4.3), so these entries
+            // are valid and should not be silently dropped.
+            let mut params = self.extract_params(&mut entry.entry.params, extract);
+            if !params.has_service_info() {
+                return;
+            }
+
+            let prop_id = params.prop_id();
+            let alt_id = params.alt_id();
+            let sub_property = top_property_name.sub_property();
+
+            let mut entries = self.get_mut_object_or_insert(top_property_name.clone());
+            if let Some(sub_property) = sub_property.clone() {
+                entries = entries
+                    .insert_or_get_mut(sub_property, Value::Object(Map::from(vec![])))
+                    .as_object_mut()
+                    .unwrap();
+            }
+
+            let mut obj = Vec::new();
+            obj.extend(extra_properties);
+            obj.extend(params.into_iter(&entry.entry.name));
+            let prop_id = entries.insert_named(prop_id, Value::Object(Map::from(obj)));
+
+            if let Some(sub_property) = sub_property {
+                entry.set_converted_to::<I>(&[
+                    top_property_name.to_cow().as_ref(),
+                    sub_property.to_cow().as_ref(),
+                    prop_id.as_str(),
+                    value_property_name.to_cow().as_ref(),
+                ]);
+            } else {
+                entry.set_converted_to::<I>(&[
+                    top_property_name.to_cow().as_ref(),
+                    prop_id.as_str(),
+                    value_property_name.to_cow().as_ref(),
+                ]);
+            }
+
+            self.track_prop(&entry.entry, top_property_name, alt_id, prop_id);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes stalwartlabs/stalwart#2884 — JMAP `ContactCard/get` silently drops `onlineServices` entries that were created without a `uri` field.

## Root Cause

In `map_named_entry()` (`src/jscontact/import/props.rs`), when a SOCIALPROFILE vCard entry has no URI value, `entry.to_text()` returns `None` and the entire entry is skipped — including all parameters (`SERVICE-TYPE`, `USERNAME`) that carry the actual data.

This happens when contacts are created via JMAP `ContactCard/set` with `onlineServices` entries that have `service` and `user` but no `uri`:

```json
"onlineServices": {
  "s1": {"service": "Signal", "user": "+46701234567"}
}
```

The JSContact→vCard export stores this as:
```
SOCIALPROFILE;SERVICE-TYPE=Signal;USERNAME=+46701234567;PROP-ID=s1:
```

Note the empty value after the colon. On the read path (vCard→JSContact), `map_named_entry` bails out because the value is `None`, even though the `uri` field is optional per RFC 9553 Section 2.4.3.

## Fix

Added an `else` branch in `map_named_entry` that processes entries with no value but meaningful parameters (SERVICE-TYPE or USERNAME). The entry is constructed with just the parameter-derived fields (`service`, `user`, contexts, etc.) and no `uri` field — matching the original JSContact input.

Also added `has_service_info()` helper on `ExtractedParams` to check for online-service-specific parameters.

## Testing

- All 42 existing tests pass
- Verified against a live Stalwart v0.15.5 instance: created contacts with mixed entries (some with URI, some without). Before the fix, entries without URI were silently dropped. After the fix, all entries round-trip correctly through JMAP write → storage → JMAP read.